### PR TITLE
add vuepress-commander

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@
 - [@kawarimidoll/vuepress-plugin-tailwind](https://github.com/kawarimidoll/vuepress-plugin-tailwind) - A VuePress plugin to use [`tailwindcss`](https://github.com/tailwindcss/tailwindcss) and [`postcss-purgecss`](https://github.com/FullHuman/purgecss) easily
 - [spekulatius/vuepress-plugin-web-monetization](https://github.com/spekulatius/vuepress-plugin-web-monetization) - Adds the web-monetization metatag to your VuePress site. Works both on page-by-page levels as well as global.
 - [vuepress-plugin-lastest-version](https://github.com/yangyang0507/vuepress-plugin-lastest-version) - Get lastest version of artifact for your vuepress doc.
+- [vuepress-commander](https://github.com/kdydesign/vuepress-commander) - vuepress-commander makes it easier to create and deploy posts in the vuepress using cli.
 
 ## Themes
 


### PR DESCRIPTION
Using vuepress, I needed a cli command that was more comfortable to use. The `extendCli` option in vuepress has the disadvantage of running and running vuepress. So I made a global cli module called vuepress-commander.

Although not plugin, many vuepress users want to use vuepress more comfortably.