### PR TITLE
docs: add dt.in.th to blogging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@
 - [ChungZH's blog (VuePress theme-blog with Netlify)](https://chungzh.cn)
 - [mrsessions blog (VuePress with Azure Static Web Apps)](https://blog.mrsessions.com)
 - [wxsm's space](https://wxsm.space)
+- [dt.in.th (VuePress × Netlify)](https://dt.in.th) - [Open Sourced](https://github.com/dtinth/dt.in.th)
 
 ### Open Source
 


### PR DESCRIPTION
After many iterations of going through PHP, WordPress, custom Node.js scripts, React-based SSG, Gatsby, over the years… 3 months ago I finally settled on VuePress.

It removes a lot of technical decisions I have to make (e.g. what Markdown extensions I need, how to organize content), because it has really good defaults and conventions. At the same time it is flexible/customizable enough for anything I might want to do. My website/portfolio is using VuePress’s default theme without ejecting and I find that enough for me.

![image](https://user-images.githubusercontent.com/193136/104093699-bd697100-52be-11eb-9c16-29cfa490c2d1.png)
