### PR TITLE
Add LINE’s Messaging API SDK for Node.js to Open Source section

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@
 - [VIZ Docs](https://docs.viz.cx) - VIZ blockchain documentation.
 - [vue-grid-layout](https://jbaysolutions.github.io/vue-grid-layout/) - Documentation for vue-grid-layout, a grid layout system for Vue.js
 - [uiv](https://uiv.wxsm.space) - Bootstrap 3 Components implemented by Vue 2.
+- [@line/bot-sdk](https://line.github.io/line-bot-sdk-nodejs/#introduction)
 
 ### Enterprise Usage
 

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@
 - [VIZ Docs](https://docs.viz.cx) - VIZ blockchain documentation.
 - [vue-grid-layout](https://jbaysolutions.github.io/vue-grid-layout/) - Documentation for vue-grid-layout, a grid layout system for Vue.js
 - [uiv](https://uiv.wxsm.space) - Bootstrap 3 Components implemented by Vue 2.
-[line-bot-sdk-nodejs](https://line.github.io/line-bot-sdk-nodejs) - LINE Messaging API SDK for nodejs
+- [line-bot-sdk-nodejs](https://line.github.io/line-bot-sdk-nodejs) - LINE Messaging API SDK for nodejs
 
 ### Enterprise Usage
 

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@
 - [VIZ Docs](https://docs.viz.cx) - VIZ blockchain documentation.
 - [vue-grid-layout](https://jbaysolutions.github.io/vue-grid-layout/) - Documentation for vue-grid-layout, a grid layout system for Vue.js
 - [uiv](https://uiv.wxsm.space) - Bootstrap 3 Components implemented by Vue 2.
-- [@line/bot-sdk](https://line.github.io/line-bot-sdk-nodejs/#introduction)
+[line-bot-sdk-nodejs](https://line.github.io/line-bot-sdk-nodejs) - LINE Messaging API SDK for nodejs
 
 ### Enterprise Usage
 


### PR DESCRIPTION

LINE Messaging API SDK for Node.js uses VuePress for documentation

![image](https://user-images.githubusercontent.com/193136/104093753-2fda5100-52bf-11eb-8b50-7db93212ed99.png)
