### PR TITLE
docs: add vuepress-plugin-demoblock-plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@
 - [vuepress-plugin-facebook-pixel](https://github.com/vittominacori/vuepress-plugin-facebook-pixel) - A VuePress plugin to use Facebook Pixel
 - [vuepress-plugin-ackee](https://github.com/spekulatius/vuepress-plugin-ackee) - Adds the Ackuee tracking code to vuePress (privacy-friendly)
 - [@snippetors/vuepress-plugin-tabs](https://www.npmjs.com/package/@snippetors/vuepress-plugin-tabs) - A VuePress plugin which renders custom markdown containers as tabs, for vuepress v2.x
+- [vuepress-plugin-demoblock-plus](https://github.com/xinlei3166/vuepress-plugin-demoblock-plus) - A Vuepress 2.x plugin that helps you add Vue examples when you document
 
 ## Themes
 


### PR DESCRIPTION
vuepress-plugin-demoblock-plus 是一个基于 Vuepress 的插件，它可以帮助你在编写文档的时候增加 Vue 示例。