### PR TITLE
Add vuepress-plugin-full-text-search2 to v2.md

### DIFF
--- a/v2.md
+++ b/v2.md
@@ -98,6 +98,7 @@
 - [vuepress-plugin-markdown-define2](https://github.com/justforuse/vuepress-plugin-markdown-define2): A plugin to define variables in markdown for Vuepress 2.
 - [@condorhero/vuepress-plugin-export-pdf-v2](https://github.com/condorheroblog/vuepress-plugin/tree/main/packages/vuepress-plugin-export-pdf-v2): A VuePress v2 plugin exports your website as a PDF file.
 - [vuepress-plugin-anchor-right](https://github.com/dingshaohua-cn/vuepress-plugin-anchor-right):  A VuePress v2 plugin,It is used to generate the right navigation directory anchor!
+- [vuepress-plugin-full-text-search2](https://github.com/ota-meshi/vuepress-plugin-full-text-search2): VuePress v2 plugin that adds full-text search box.
 
 <!-- duplicate plugins with same feature -->
 


### PR DESCRIPTION
This PR adds [vuepress-plugin-full-text-search2](https://github.com/ota-meshi/vuepress-plugin-full-text-search2) to v2.md.