### PR TITLE
Added a link to the WordPress to VuePress 2 migration script.

### DIFF
--- a/v2.md
+++ b/v2.md
@@ -112,6 +112,7 @@
 - [vuepress-plugin-umami-analytics](https://github.com/azat-io/azat-io/tree/main/plugins/umami-analytics): Plugin for using Umami analytics
 - [vuepress-plugin-alert](https://github.com/wuwb/vuepress-plugin-alert): Plugin for add site announcement on the top right corner.
 - [vuepress-plugin-blog-sync](https://github.com/flytam/vuepress-plugin-blog-sync): Input blog site info, generate VuePress2 site automatically | 输入网站基本信息，一键生成 VuePress2 文档站
+- [@cinar/wordpress-to-vuepress-migration](https://github.com/cinar/wordpress-to-vuepress-migration): WordPress to VuePress 2 migration script.
 
 <!--
   This is the end of the list, place your plugin above.


### PR DESCRIPTION
Added a link to the WordPress to VuePress 2 migration script at https://github.com/cinar/wordpress-to-vuepress-migration.