### PR TITLE
Adding a plugin to the community section

### DIFF
--- a/v2.md
+++ b/v2.md
@@ -112,6 +112,7 @@
 - [vuepress-plugin-umami-analytics](https://github.com/azat-io/azat-io/tree/main/plugins/umami-analytics): Plugin for using Umami analytics
 - [vuepress-plugin-alert](https://github.com/wuwb/vuepress-plugin-alert): Plugin for add site announcement on the top right corner.
 - [vuepress-plugin-blog-sync](https://github.com/flytam/vuepress-plugin-blog-sync): Input blog site info, generate VuePress2 site automatically | 输入网站基本信息，一键生成 VuePress2 文档站
+- [vuepress-plugin-github-linkify](https://github.com/TheDragonCode/vuepress-plugin-github-linkify): Adding and fixing GitHub links
 
 <!--
   This is the end of the list, place your plugin above.


### PR DESCRIPTION
Added a mention of a plugin for converting links to GitHub projects.

For example:

![before](https://raw.githubusercontent.com/TheDragonCode/vuepress-plugin-github-linkify/main/.github/images/before.png)

![after](https://raw.githubusercontent.com/TheDragonCode/vuepress-plugin-github-linkify/main/.github/images/after.png)